### PR TITLE
proposed commits to make addAttribute() have a prefix parameter

### DIFF
--- a/src/neuroprovenance.c
+++ b/src/neuroprovenance.c
@@ -61,7 +61,7 @@ ProcessPtr newProcess(ProvObjectPtr p_prov, const char* startTime, const char* e
     RecordPtr p_record = ((ProvPtr)p_prov)->p_record;
     IDREF act_id = newActivity(p_record, NULL, startTime, endTime);
     if (type != NULL)
-        addAttribute(p_record, act_id, "type", type);
+        addAttribute(p_record, act_id, "prov", "type", type);
     return((ProcessPtr)act_id);
 }
 
@@ -71,11 +71,11 @@ REFID newProcessInput(ProvObjectPtr p_prov, ProcessPtr p_proc, const char* name,
     RecordPtr p_record = ((ProvPtr)p_prov)->p_record;
     IDREF id = newEntity(p_record);
     if (type == NULL)
-        addAttribute(p_record, id, "type", "ni:input");
+        addAttribute(p_record, id, "prov", "type", "ni:input");
     else
-        addAttribute(p_record, id, "type", type);
-    addAttribute(p_record, id, "name", name);
-    addAttribute(p_record, id, "value", value);
+        addAttribute(p_record, id, "prov", "type", type);
+    addAttribute(p_record, id, "ni", "name", name);
+    addAttribute(p_record, id, "ni", "value", value);
     newUsedRecord(p_record, (IDREF)p_proc, id, NULL);
     return((REFID)id);
 }
@@ -86,11 +86,11 @@ REFID newProcessOutput(ProvObjectPtr p_prov, ProcessPtr p_proc, const char* name
     RecordPtr p_record = ((ProvPtr)p_prov)->p_record;
     IDREF id = newEntity(p_record);
     if (type == NULL)
-        addAttribute(p_record, id, "type", "ni:output");
+        addAttribute(p_record, id, "prov", "type", "ni:output");
     else
-        addAttribute(p_record, id, "type", type);
-    addAttribute(p_record, id, "name", name);
-    addAttribute(p_record, id, "value", value);
+        addAttribute(p_record, id, "prov", "type", type);
+    addAttribute(p_record, id, "ni", "name", name);
+    addAttribute(p_record, id, "ni", "value", value);
     newGeneratedByRecord(p_record, id, (IDREF)p_proc, NULL);
     return((REFID)id);
 }
@@ -151,13 +151,13 @@ REFID newFile(ProvObjectPtr p_prov, const char* filename, const char* type)
     IDREF id = newEntity(p_record);
     unsigned char* p_hash;
     if (type == NULL)
-        addAttribute(p_record, id, "type", "ni:file");
+        addAttribute(p_record, id, "prov", "type", "ni:file");
     else
-        addAttribute(p_record, id, "type", type);
-    addAttribute(p_record, id, "path", filename);
+        addAttribute(p_record, id, "prov", "type", type);
+    addAttribute(p_record, id, "ni", "path", filename);
     p_hash = get_md5_hash(filename);
     if (p_hash != NULL){
-        addAttribute(p_record, id, "md5sum", p_hash);
+        addAttribute(p_record, id, "ni", "md5sum", p_hash);
         free(p_hash);
     }
     return((REFID)id);
@@ -170,11 +170,11 @@ REFID newFileCollection(ProvObjectPtr p_prov, const char** filenames, int n_file
     IDREF id = newEntity(p_record);
     int i;
     if (type == NULL)
-        addAttribute(p_record, id, "type", "ni:filelist");
+        addAttribute(p_record, id, "prov", "type", "ni:filelist");
     else
-        addAttribute(p_record, id, "type", type);
+        addAttribute(p_record, id, "prov", "type", type);
     for(i=0; i<n_files; i++)
-        addAttribute(p_record, id, "path", filenames[i]);
+        addAttribute(p_record, id, "ni", "path", filenames[i]);
     return((REFID)id);
 }
 
@@ -183,8 +183,8 @@ REFID addEnvironVariable(ProvObjectPtr p_prov, ProcessPtr p_proc, const char* na
 {
     RecordPtr p_record = ((ProvPtr)p_prov)->p_record;
     IDREF id = newEntity(p_record);
-    addAttribute(p_record, id, "type", "ni:environ");
-    addAttribute(p_record, id, name, getenv(name));
+    addAttribute(p_record, id, "prov", "type", "ni:environ");
+    addAttribute(p_record, id, NULL, name, getenv(name));
     return((REFID)id);
 }
 
@@ -195,7 +195,7 @@ REFID addAllEnvironVariables(ProvObjectPtr p_prov, ProcessPtr p_proc, char **env
     IDREF id = newEntity(p_record);
     char buffer[255];
     int i;
-    addAttribute(p_record, id, "type", "ni:environ");
+    addAttribute(p_record, id, "prov", "type", "ni:environ");
     char** env;
     for (env = envp; *env != 0; env++)
     {
@@ -206,7 +206,7 @@ REFID addAllEnvironVariables(ProvObjectPtr p_prov, ProcessPtr p_proc, char **env
        while (thisEnv[pos++] != '=');
        name = strndup(thisEnv, pos-1);
        if (name[0] != '_')
-           addAttribute(p_record, id, name, &thisEnv[pos]);
+           addAttribute(p_record, id, NULL, name, &thisEnv[pos]);
        free(name);
     }
     return((REFID)id);
@@ -216,7 +216,7 @@ REFID addAllEnvironVariables(ProvObjectPtr p_prov, ProcessPtr p_proc, char **env
 int addKeyValuePair(ProvObjectPtr p_prov, ProcessPtr p_proc, const char* key, const char* value)
 {
     RecordPtr p_record = ((ProvPtr)p_prov)->p_record;
-    addAttribute(p_record, (IDREF)p_proc, key, value);
+    addAttribute(p_record, (IDREF)p_proc, NULL, key, value);
     return(0);
 }
 
@@ -241,7 +241,7 @@ int addCommandLine(ProvObjectPtr p_prov, ProcessPtr p_proc, int argc, char** arg
     RecordPtr p_record = ((ProvPtr)p_prov)->p_record;
     IDREF id = (IDREF)p_proc;
     char *cmdline = get_cmdline(argc, argv);
-    addAttribute(p_record, id, "cmdline", cmdline);
+    addAttribute(p_record, id, "ni", "cmdline", cmdline);
     free(cmdline);
     return(0);
 }
@@ -256,7 +256,7 @@ int addDependency(ProvObjectPtr p_prov, ProcessPtr parent, ProcessPtr child)
 int addType(ProvObjectPtr p_prov, REFID id, const char* type)
 {
     RecordPtr p_record = ((ProvPtr)p_prov)->p_record;
-    addAttribute(p_record, id, "type", type);
+    addAttribute(p_record, id, "prov", "type", type);
     return(0);
 }
 

--- a/src/provenance.h
+++ b/src/provenance.h
@@ -50,7 +50,7 @@ IDREF newSpecializationOfRecord(RecordPtr p_record, IDREF entity1, IDREF entity2
 IDREF newHasAnnotationRecord(RecordPtr p_rec, IDREF thing, IDREF note);
 
 /* Record manipulation routines */
-int addAttribute(RecordPtr p_record, IDREF id, const char* key, const char* value);
+int addAttribute(RecordPtr p_record, IDREF id, const char * prefix, const char* localName, const char* value);
 int changeID(RecordPtr, IDREF, const char*);
 int addProvAsAccount(RecordPtr p_record, const ProvPtr p_prov, const char *prefix);
 

--- a/src/testneuroprov.xml
+++ b/src/testneuroprov.xml
@@ -1,67 +1,86 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<container xmlns:opm="http://openprovenance.org/prov-xml#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:prov="http://openprovenance.org/prov-xml#" xmlns:incf="http://incf.org/incf-schema" xmlns:ni="https://github.com/INCF/ProvenanceLibrary/wiki/terms" id="BET">
+<container xmlns:opm="http://openprovenance.org/prov-xml#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:prov="http://openprovenance.org/prov-xml#" xmlns:incf="http://incf.org/incf-schema" xmlns:ni="http://this.namespace.needs.to/be.decided" xmlns="http://openprovenance.org/prov-xml#" id="BET">
   <records>
     <activity id="a_0">
       <startTime>11/30/11 00:13:20.650432 EST</startTime>
       <endTime>11/30/11 00:13:20.650550 EST</endTime>
-      <type>ni:brain_extraction</type>
-      <cmdline>/Users/satra/Dropbox/WORK/PROJECTS/INCF/ProvenanceLibrary/src/testneuroprov -c 2</cmdline>
-      <program>/Users/satra/Dropbox/WORK/PROJECTS/INCF/ProvenanceLibrary/src/testneuroprov</program>
+      <prov:type>ni:brain_extraction</prov:type>
+      <ni:cmdline>./testneuroprov</ni:cmdline>
+      <program>./testneuroprov</program>
       <version>1.0.0</version>
     </activity>
     <entity id="e_0">
-      <type>ni:input</type>
-      <name>arg1</name>
-      <value>-c</value>
+      <prov:type>ni:environ</prov:type>
+      <HOSTNAME>varese.dhe.duke.edu</HOSTNAME>
+      <SELINUX_ROLE_REQUESTED></SELINUX_ROLE_REQUESTED>
+      <TERM>xterm</TERM>
+      <SHELL>/bin/bash</SHELL>
+      <HISTSIZE>1000</HISTSIZE>
+      <GLOBUS_PATH>/opt/globus-client-5.0.0.rc3-r1</GLOBUS_PATH>
+      <GLOBUS_LOCATION>/opt/globus-client-5.0.0.rc3-r1</GLOBUS_LOCATION>
+      <SSH_CLIENT>152.16.195.158 2993 22</SSH_CLIENT>
+      <PERL5LIB>/opt/globus-client-5.0.0.rc3-r1/lib/perl</PERL5LIB>
+      <FSLMULTIFILEQUIT>TRUE</FSLMULTIFILEQUIT>
+      <SELINUX_USE_CURRENT_RANGE></SELINUX_USE_CURRENT_RANGE>
+      <QTDIR>/usr/lib64/qt-3.3</QTDIR>
+      <QTINC>/usr/lib64/qt-3.3/include</QTINC>
+      <SSH_TTY>/dev/pts/25</SSH_TTY>
+      <USER>gadde</USER>
+      <LD_LIBRARY_PATH>.</LD_LIBRARY_PATH>
+      <LS_COLORS>no=00:fi=00:di=01;36:ln=01;36:pi=40;33:so=01;35:bd=40;33;01:cd=40;33;01:or=01;05;37;41:mi=01;05;37;41:ex=01;32:*.cmd=01;32:*.exe=01;32:*.com=01;32:*.btm=01;32:*.bat=01;32:*.sh=01;32:*.csh=01;32:*.tar=01;31:*.tgz=01;31:*.arj=01;31:*.taz=01;31:*.lzh=01;31:*.zip=01;31:*.z=01;31:*.Z=01;31:*.gz=01;31:*.bz2=01;31:*.bz=01;31:*.tz=01;31:*.rpm=01;31:*.cpio=01;31:*.jpg=01;35:*.gif=01;35:*.bmp=01;35:*.xbm=01;35:*.xpm=01;35:*.png=01;35:*.tif=01;35:</LS_COLORS>
+      <LIBPATH>/opt/globus-client-5.0.0.rc3-r1/lib:/usr/lib:/lib</LIBPATH>
+      <MAIL>/var/spool/mail/gadde</MAIL>
+      <PATH>/usr/lib64/qt-3.3/bin:/opt/globus-client-5.0.0.rc3-r1/bin:/opt/globus-client-5.0.0.rc3-r1/sbin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:/usr/local/packages/bxh_xcede_tools/bin:/usr/local/packages/dcmtk/bin:/usr/local/packages/fsl/bin:/home/gadde/bin</PATH>
+      <FSLMACHTYPE>linux_64-gcc4.4</FSLMACHTYPE>
+      <PWD>/home/gadde/checkedout/ProvenanceLibrary/src</PWD>
+      <XMODIFIERS>@im=none</XMODIFIERS>
+      <KDE_IS_PRELINKED>1</KDE_IS_PRELINKED>
+      <LANG>en_US.UTF-8</LANG>
+      <MODULEPATH>/usr/share/Modules/modulefiles:/etc/modulefiles</MODULEPATH>
+      <FSLTCLSH>/usr/local/packages/fsl/bin/fsltclsh</FSLTCLSH>
+      <LOADEDMODULES></LOADEDMODULES>
+      <KDEDIRS>/usr</KDEDIRS>
+      <FSLMACHINELIST></FSLMACHINELIST>
+      <MYPROXY_SERVER>certs.nbirn.org</MYPROXY_SERVER>
+      <SELINUX_LEVEL_REQUESTED></SELINUX_LEVEL_REQUESTED>
+      <FSLREMOTECALL></FSLREMOTECALL>
+      <FSLCONFDIR>/usr/local/packages/fsl/config</FSLCONFDIR>
+      <FSLWISH>/usr/local/packages/fsl/bin/fslwish</FSLWISH>
+      <SSH_ASKPASS>/usr/libexec/openssh/gnome-ssh-askpass</SSH_ASKPASS>
+      <HISTCONTROL>ignoredups</HISTCONTROL>
+      <SHLVL>1</SHLVL>
+      <HOME>/home/gadde</HOME>
+      <LANGUAGE></LANGUAGE>
+      <DYLD_LIBRARY_PATH>/opt/globus-client-5.0.0.rc3-r1/lib</DYLD_LIBRARY_PATH>
+      <LOGNAME>gadde</LOGNAME>
+      <QTLIB>/usr/lib64/qt-3.3/lib</QTLIB>
+      <FSLDIR>/usr/local/packages/fsl</FSLDIR>
+      <CVS_RSH>ssh</CVS_RSH>
+      <SSH_CONNECTION>152.16.195.158 2993 10.152.25.5 22</SSH_CONNECTION>
+      <MODULESHOME>/usr/share/Modules</MODULESHOME>
+      <LESSOPEN>|/usr/bin/lesspipe.sh %s</LESSOPEN>
+      <SHLIB_PATH>/opt/globus-client-5.0.0.rc3-r1/lib</SHLIB_PATH>
+      <DISPLAY>localhost:10.0</DISPLAY>
+      <FSLLOCKDIR></FSLLOCKDIR>
+      <FSLOUTPUTTYPE>NIFTI_GZ</FSLOUTPUTTYPE>
+      <G_BROKEN_FILENAMES>1</G_BROKEN_FILENAMES>
+      <module>() {  eval `/usr/bin/modulecmd bash $*`
+}</module>
+      <OLDPWD>/home/gadde/checkedout/ProvenanceLibrary</OLDPWD>
     </entity>
+    <entity id="e_0"/>
     <dependencies>
-      <used id="u_0">
-        <activity ref="a_0"/>
-        <entity ref="e_0"/>
-      </used>
-      <used id="u_1">
-        <activity ref="a_0"/>
-        <entity ref="e_1"/>
-      </used>
       <wasGeneratedBy id="wgb_0">
-        <entity ref="e_3"/>
-        <activity ref="a_0"/>
-      </wasGeneratedBy>
-      <wasGeneratedBy id="wgb_1">
-        <entity ref="e_4"/>
+        <entity ref="e_0"/>
         <activity ref="a_0"/>
       </wasGeneratedBy>
     </dependencies>
-    <entity id="e_1">
-      <type>ni:input</type>
-      <name>arg2</name>
-      <value>2</value>
-    </entity>
-    <entity id="e_2">
-      <type>ni:environ</type>
-      <PATH>/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:/usr/X11/bin:/opt/local/bin:/usr/local/git/bin</PATH>
-      <TMPDIR>/var/folders/1l/ly3rt98n1sd4cdw03l7ncf1r0000gn/T/</TMPDIR>
-      <LOGNAME>satra</LOGNAME>
-      <COMMAND_MODE>unix2003</COMMAND_MODE>
-      <DISPLAY>/tmp/launch-9Dx8oH/org.macosforge.xquartz:0</DISPLAY>
-      <Apple_PubSub_Socket_Render>/tmp/launch-PeLnXj/Render</Apple_PubSub_Socket_Render>
-      <USER>satra</USER>
-      <SHELL>/bin/bash</SHELL>
-      <SSH_AUTH_SOCK>/tmp/launch-hjVTaO/Listeners</SSH_AUTH_SOCK>
-      <HOME>/Users/satra</HOME>
-    </entity>
-    <entity id="e_3">
-      <type>ni:output</type>
-      <path>./testneuroprov.c</path>
-      <md5sum>1913486fff3eefbdb0aea05778f57ec6</md5sum>
-      <name>warped_file</name>
-      <type>ni:normalized</type>
-    </entity>
-    <entity id="e_4">
-      <type>ni:output</type>
-      <name>pearson_correlation_coefficient</name>
-      <value>.234</value>
-      <type>ni:statistic</type>
-    </entity>
+    <entity id="e_0"/>
+    <dependencies>
+      <wasGeneratedBy id="wgb_0">
+        <entity ref="e_0"/>
+        <activity ref="a_0"/>
+      </wasGeneratedBy>
+    </dependencies>
   </records>
 </container>

--- a/src/testneuroprov2.xml
+++ b/src/testneuroprov2.xml
@@ -1,70 +1,89 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<container xmlns:opm="http://openprovenance.org/prov-xml#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:prov="http://openprovenance.org/prov-xml#" xmlns:incf="http://incf.org/incf-schema" xmlns:ni="https://github.com/INCF/ProvenanceLibrary/wiki/terms" id="NewStuff">
+<container xmlns:opm="http://openprovenance.org/prov-xml#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:prov="http://openprovenance.org/prov-xml#" xmlns:incf="http://incf.org/incf-schema" xmlns:ni="http://this.namespace.needs.to/be.decided" xmlns="http://openprovenance.org/prov-xml#" id="NewStuff">
   <records>
     <account id="ac_0">
-      <records>
+      <records xmlns="http://openprovenance.org/prov-xml#" xmlns:prov="http://openprovenance.org/prov-xml#" xmlns:ni="http://this.namespace.needs.to/be.decided">
     <activity id="ac_0_a_0">
       <startTime>11/30/11 00:13:20.650432 EST</startTime>
       <endTime>11/30/11 00:13:20.650550 EST</endTime>
-      <type>ni:brain_extraction</type>
-      <cmdline>/Users/satra/Dropbox/WORK/PROJECTS/INCF/ProvenanceLibrary/src/testneuroprov -c 2</cmdline>
-      <program>/Users/satra/Dropbox/WORK/PROJECTS/INCF/ProvenanceLibrary/src/testneuroprov</program>
+      <prov:type>ni:brain_extraction</prov:type>
+      <ni:cmdline>./testneuroprov</ni:cmdline>
+      <program>./testneuroprov</program>
       <version>1.0.0</version>
     </activity>
     <entity id="ac_0_e_0">
-      <type>ni:input</type>
-      <name>arg1</name>
-      <value>-c</value>
+      <prov:type>ni:environ</prov:type>
+      <HOSTNAME>varese.dhe.duke.edu</HOSTNAME>
+      <SELINUX_ROLE_REQUESTED/>
+      <TERM>xterm</TERM>
+      <SHELL>/bin/bash</SHELL>
+      <HISTSIZE>1000</HISTSIZE>
+      <GLOBUS_PATH>/opt/globus-client-5.0.0.rc3-r1</GLOBUS_PATH>
+      <GLOBUS_LOCATION>/opt/globus-client-5.0.0.rc3-r1</GLOBUS_LOCATION>
+      <SSH_CLIENT>152.16.195.158 2993 22</SSH_CLIENT>
+      <PERL5LIB>/opt/globus-client-5.0.0.rc3-r1/lib/perl</PERL5LIB>
+      <FSLMULTIFILEQUIT>TRUE</FSLMULTIFILEQUIT>
+      <SELINUX_USE_CURRENT_RANGE/>
+      <QTDIR>/usr/lib64/qt-3.3</QTDIR>
+      <QTINC>/usr/lib64/qt-3.3/include</QTINC>
+      <SSH_TTY>/dev/pts/25</SSH_TTY>
+      <USER>gadde</USER>
+      <LD_LIBRARY_PATH>.</LD_LIBRARY_PATH>
+      <LS_COLORS>no=00:fi=00:di=01;36:ln=01;36:pi=40;33:so=01;35:bd=40;33;01:cd=40;33;01:or=01;05;37;41:mi=01;05;37;41:ex=01;32:*.cmd=01;32:*.exe=01;32:*.com=01;32:*.btm=01;32:*.bat=01;32:*.sh=01;32:*.csh=01;32:*.tar=01;31:*.tgz=01;31:*.arj=01;31:*.taz=01;31:*.lzh=01;31:*.zip=01;31:*.z=01;31:*.Z=01;31:*.gz=01;31:*.bz2=01;31:*.bz=01;31:*.tz=01;31:*.rpm=01;31:*.cpio=01;31:*.jpg=01;35:*.gif=01;35:*.bmp=01;35:*.xbm=01;35:*.xpm=01;35:*.png=01;35:*.tif=01;35:</LS_COLORS>
+      <LIBPATH>/opt/globus-client-5.0.0.rc3-r1/lib:/usr/lib:/lib</LIBPATH>
+      <MAIL>/var/spool/mail/gadde</MAIL>
+      <PATH>/usr/lib64/qt-3.3/bin:/opt/globus-client-5.0.0.rc3-r1/bin:/opt/globus-client-5.0.0.rc3-r1/sbin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:/usr/local/packages/bxh_xcede_tools/bin:/usr/local/packages/dcmtk/bin:/usr/local/packages/fsl/bin:/home/gadde/bin</PATH>
+      <FSLMACHTYPE>linux_64-gcc4.4</FSLMACHTYPE>
+      <PWD>/home/gadde/checkedout/ProvenanceLibrary/src</PWD>
+      <XMODIFIERS>@im=none</XMODIFIERS>
+      <KDE_IS_PRELINKED>1</KDE_IS_PRELINKED>
+      <LANG>en_US.UTF-8</LANG>
+      <MODULEPATH>/usr/share/Modules/modulefiles:/etc/modulefiles</MODULEPATH>
+      <FSLTCLSH>/usr/local/packages/fsl/bin/fsltclsh</FSLTCLSH>
+      <LOADEDMODULES/>
+      <KDEDIRS>/usr</KDEDIRS>
+      <FSLMACHINELIST/>
+      <MYPROXY_SERVER>certs.nbirn.org</MYPROXY_SERVER>
+      <SELINUX_LEVEL_REQUESTED/>
+      <FSLREMOTECALL/>
+      <FSLCONFDIR>/usr/local/packages/fsl/config</FSLCONFDIR>
+      <FSLWISH>/usr/local/packages/fsl/bin/fslwish</FSLWISH>
+      <SSH_ASKPASS>/usr/libexec/openssh/gnome-ssh-askpass</SSH_ASKPASS>
+      <HISTCONTROL>ignoredups</HISTCONTROL>
+      <SHLVL>1</SHLVL>
+      <HOME>/home/gadde</HOME>
+      <LANGUAGE/>
+      <DYLD_LIBRARY_PATH>/opt/globus-client-5.0.0.rc3-r1/lib</DYLD_LIBRARY_PATH>
+      <LOGNAME>gadde</LOGNAME>
+      <QTLIB>/usr/lib64/qt-3.3/lib</QTLIB>
+      <FSLDIR>/usr/local/packages/fsl</FSLDIR>
+      <CVS_RSH>ssh</CVS_RSH>
+      <SSH_CONNECTION>152.16.195.158 2993 10.152.25.5 22</SSH_CONNECTION>
+      <MODULESHOME>/usr/share/Modules</MODULESHOME>
+      <LESSOPEN>|/usr/bin/lesspipe.sh %s</LESSOPEN>
+      <SHLIB_PATH>/opt/globus-client-5.0.0.rc3-r1/lib</SHLIB_PATH>
+      <DISPLAY>localhost:10.0</DISPLAY>
+      <FSLLOCKDIR/>
+      <FSLOUTPUTTYPE>NIFTI_GZ</FSLOUTPUTTYPE>
+      <G_BROKEN_FILENAMES>1</G_BROKEN_FILENAMES>
+      <module>() {  eval `/usr/bin/modulecmd bash $*`
+}</module>
+      <OLDPWD>/home/gadde/checkedout/ProvenanceLibrary</OLDPWD>
     </entity>
+    <entity id="ac_0_e_0"/>
     <dependencies>
-      <used id="ac_0_u_0">
-        <activity ref="ac_0_a_0"/>
-        <entity ref="ac_0_e_0"/>
-      </used>
-      <used id="ac_0_u_1">
-        <activity ref="ac_0_a_0"/>
-        <entity ref="ac_0_e_1"/>
-      </used>
       <wasGeneratedBy id="ac_0_wgb_0">
-        <entity ref="ac_0_e_3"/>
-        <activity ref="ac_0_a_0"/>
-      </wasGeneratedBy>
-      <wasGeneratedBy id="ac_0_wgb_1">
-        <entity ref="ac_0_e_4"/>
+        <entity ref="ac_0_e_0"/>
         <activity ref="ac_0_a_0"/>
       </wasGeneratedBy>
     </dependencies>
-    <entity id="ac_0_e_1">
-      <type>ni:input</type>
-      <name>arg2</name>
-      <value>2</value>
-    </entity>
-    <entity id="ac_0_e_2">
-      <type>ni:environ</type>
-      <PATH>/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:/usr/X11/bin:/opt/local/bin:/usr/local/git/bin</PATH>
-      <TMPDIR>/var/folders/1l/ly3rt98n1sd4cdw03l7ncf1r0000gn/T/</TMPDIR>
-      <LOGNAME>satra</LOGNAME>
-      <COMMAND_MODE>unix2003</COMMAND_MODE>
-      <DISPLAY>/tmp/launch-9Dx8oH/org.macosforge.xquartz:0</DISPLAY>
-      <Apple_PubSub_Socket_Render>/tmp/launch-PeLnXj/Render</Apple_PubSub_Socket_Render>
-      <USER>satra</USER>
-      <SHELL>/bin/bash</SHELL>
-      <SSH_AUTH_SOCK>/tmp/launch-hjVTaO/Listeners</SSH_AUTH_SOCK>
-      <HOME>/Users/satra</HOME>
-    </entity>
-    <entity id="ac_0_e_3">
-      <type>ni:output</type>
-      <path>./testneuroprov.c</path>
-      <md5sum>1913486fff3eefbdb0aea05778f57ec6</md5sum>
-      <name>warped_file</name>
-      <type>ni:normalized</type>
-    </entity>
-    <entity id="ac_0_e_4">
-      <type>ni:output</type>
-      <name>pearson_correlation_coefficient</name>
-      <value>.234</value>
-      <type>ni:statistic</type>
-    </entity>
+    <entity id="ac_0_e_0"/>
+    <dependencies>
+      <wasGeneratedBy id="ac_0_wgb_0">
+        <entity ref="ac_0_e_0"/>
+        <activity ref="ac_0_a_0"/>
+      </wasGeneratedBy>
+    </dependencies>
   </records>
     </account>
   </records>

--- a/src/testprov.c
+++ b/src/testprov.c
@@ -41,24 +41,24 @@ main(int argc, char **argv, char** envp)
 
     // Add program information
     act_id = newActivity(p_record, NULL, "11/30/11 00:13:20.650432 EST", "11/30/11 00:13:20.650550 EST");
-    addAttribute(p_record, act_id, "type", "program");
-    addAttribute(p_record, act_id, "name", argv[0]);
-    addAttribute(p_record, act_id, "version", version);
+    addAttribute(p_record, act_id, "prov", "type", "program");
+    addAttribute(p_record, act_id, "ni", "name", argv[0]);
+    addAttribute(p_record, act_id, "ni", "version", version);
     char * cmdline = get_cmdline(argc, argv);
-    addAttribute(p_record, act_id, "cmdline", cmdline);
+    addAttribute(p_record, act_id, "ni", "cmdline", cmdline);
     free(cmdline);
 
     //Add all input parameters. if you use getopt this can be refined further
     for(i=1;i<argc; i++){
         id = newEntity(p_record);
-        addAttribute(p_record, id, "type", "input");
+        addAttribute(p_record, id, "prov", "type", "input");
         sprintf(arg, "arg%d", i);
-        addAttribute(p_record, id, arg, argv[i]);
+        addAttribute(p_record, id, NULL, arg, argv[i]);
         newUsedRecord(p_record, act_id, id, NULL);
     }
 
     id = newEntity(p_record);
-    addAttribute(p_record, id, "type", "environment");
+    addAttribute(p_record, id, "prov", "type", "environment");
     // add all environment variables
     char** env;
     for (env = envp; *env != 0; env++)
@@ -70,22 +70,22 @@ main(int argc, char **argv, char** envp)
        while (thisEnv[pos++] != '=');
        name = strndup(thisEnv, pos-1);
        if (name[0] != '_')
-           addAttribute(p_record, id, name, &thisEnv[pos]);
+           addAttribute(p_record, id, NULL, name, &thisEnv[pos]);
        free(name);
     }
 
     id = newEntity(p_record);
-    addAttribute(p_record, id, "type", "runtime");
+    addAttribute(p_record, id, "prov", "type", "runtime");
     // add runtime info such as walltime, cputime, host,
 
     id = newEntity(p_record);
-    addAttribute(p_record, id, "type", "output:file");
-    addAttribute(p_record, id, "warped_file", "/full/path/to/file");
+    addAttribute(p_record, id, "prov", "type", "output:file");
+    addAttribute(p_record, id, "ni", "warped_file", "/full/path/to/file");
     newGeneratedByRecord(p_record, id, act_id, NULL);
 
     id = newEntity(p_record);
-    addAttribute(p_record, id, "type", "output:stat");
-    addAttribute(p_record, id, "pearson_correlation_coefficient", ".234");
+    addAttribute(p_record, id, "prov", "type", "output:stat");
+    addAttribute(p_record, id, "ni", "pearson_correlation_coefficient", ".234");
     newGeneratedByRecord(p_record, id, act_id, NULL);
 
     /* Test i/o manipulations */

--- a/src/testprov.xml
+++ b/src/testprov.xml
@@ -1,71 +1,87 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<container xmlns:opm="http://openprovenance.org/prov-xml#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:prov="http://openprovenance.org/prov-xml#" xmlns:incf="http://incf.org/incf-schema" id="1">
+<container xmlns:opm="http://openprovenance.org/prov-xml#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:prov="http://openprovenance.org/prov-xml#" xmlns:incf="http://incf.org/incf-schema" xmlns:ni="http://this.namespace.needs.to/be.decided" xmlns="http://openprovenance.org/prov-xml#" id="1">
   <records>
     <activity id="a_0">
       <startTime>11/30/11 00:13:20.650432 EST</startTime>
       <endTime>11/30/11 00:13:20.650550 EST</endTime>
-      <type>program</type>
-      <name>/Users/satra/Dropbox/WORK/PROJECTS/INCF/ProvenanceLibrary/src/testprov</name>
-      <version>1.0.0</version>
-      <cmdline>/Users/satra/Dropbox/WORK/PROJECTS/INCF/ProvenanceLibrary/src/testprov -c 2 -m</cmdline>
+      <prov:type>program</prov:type>
+      <ni:name>./testprov</ni:name>
+      <ni:version>1.0.0</ni:version>
+      <ni:cmdline>./testprov</ni:cmdline>
     </activity>
     <entity id="e_0">
-      <type>input</type>
-      <arg1>-c</arg1>
+      <prov:type>environment</prov:type>
+      <HOSTNAME>varese.dhe.duke.edu</HOSTNAME>
+      <SELINUX_ROLE_REQUESTED></SELINUX_ROLE_REQUESTED>
+      <TERM>xterm</TERM>
+      <SHELL>/bin/bash</SHELL>
+      <HISTSIZE>1000</HISTSIZE>
+      <GLOBUS_PATH>/opt/globus-client-5.0.0.rc3-r1</GLOBUS_PATH>
+      <GLOBUS_LOCATION>/opt/globus-client-5.0.0.rc3-r1</GLOBUS_LOCATION>
+      <SSH_CLIENT>152.16.195.158 2993 22</SSH_CLIENT>
+      <PERL5LIB>/opt/globus-client-5.0.0.rc3-r1/lib/perl</PERL5LIB>
+      <FSLMULTIFILEQUIT>TRUE</FSLMULTIFILEQUIT>
+      <SELINUX_USE_CURRENT_RANGE></SELINUX_USE_CURRENT_RANGE>
+      <QTDIR>/usr/lib64/qt-3.3</QTDIR>
+      <QTINC>/usr/lib64/qt-3.3/include</QTINC>
+      <SSH_TTY>/dev/pts/25</SSH_TTY>
+      <USER>gadde</USER>
+      <LD_LIBRARY_PATH>.</LD_LIBRARY_PATH>
+      <LS_COLORS>no=00:fi=00:di=01;36:ln=01;36:pi=40;33:so=01;35:bd=40;33;01:cd=40;33;01:or=01;05;37;41:mi=01;05;37;41:ex=01;32:*.cmd=01;32:*.exe=01;32:*.com=01;32:*.btm=01;32:*.bat=01;32:*.sh=01;32:*.csh=01;32:*.tar=01;31:*.tgz=01;31:*.arj=01;31:*.taz=01;31:*.lzh=01;31:*.zip=01;31:*.z=01;31:*.Z=01;31:*.gz=01;31:*.bz2=01;31:*.bz=01;31:*.tz=01;31:*.rpm=01;31:*.cpio=01;31:*.jpg=01;35:*.gif=01;35:*.bmp=01;35:*.xbm=01;35:*.xpm=01;35:*.png=01;35:*.tif=01;35:</LS_COLORS>
+      <LIBPATH>/opt/globus-client-5.0.0.rc3-r1/lib:/usr/lib:/lib</LIBPATH>
+      <MAIL>/var/spool/mail/gadde</MAIL>
+      <PATH>/usr/lib64/qt-3.3/bin:/opt/globus-client-5.0.0.rc3-r1/bin:/opt/globus-client-5.0.0.rc3-r1/sbin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:/usr/local/packages/bxh_xcede_tools/bin:/usr/local/packages/dcmtk/bin:/usr/local/packages/fsl/bin:/home/gadde/bin</PATH>
+      <FSLMACHTYPE>linux_64-gcc4.4</FSLMACHTYPE>
+      <PWD>/home/gadde/checkedout/ProvenanceLibrary/src</PWD>
+      <XMODIFIERS>@im=none</XMODIFIERS>
+      <KDE_IS_PRELINKED>1</KDE_IS_PRELINKED>
+      <LANG>en_US.UTF-8</LANG>
+      <MODULEPATH>/usr/share/Modules/modulefiles:/etc/modulefiles</MODULEPATH>
+      <FSLTCLSH>/usr/local/packages/fsl/bin/fsltclsh</FSLTCLSH>
+      <LOADEDMODULES></LOADEDMODULES>
+      <KDEDIRS>/usr</KDEDIRS>
+      <FSLMACHINELIST></FSLMACHINELIST>
+      <MYPROXY_SERVER>certs.nbirn.org</MYPROXY_SERVER>
+      <SELINUX_LEVEL_REQUESTED></SELINUX_LEVEL_REQUESTED>
+      <FSLREMOTECALL></FSLREMOTECALL>
+      <FSLCONFDIR>/usr/local/packages/fsl/config</FSLCONFDIR>
+      <FSLWISH>/usr/local/packages/fsl/bin/fslwish</FSLWISH>
+      <SSH_ASKPASS>/usr/libexec/openssh/gnome-ssh-askpass</SSH_ASKPASS>
+      <HISTCONTROL>ignoredups</HISTCONTROL>
+      <SHLVL>1</SHLVL>
+      <HOME>/home/gadde</HOME>
+      <LANGUAGE></LANGUAGE>
+      <DYLD_LIBRARY_PATH>/opt/globus-client-5.0.0.rc3-r1/lib</DYLD_LIBRARY_PATH>
+      <LOGNAME>gadde</LOGNAME>
+      <QTLIB>/usr/lib64/qt-3.3/lib</QTLIB>
+      <FSLDIR>/usr/local/packages/fsl</FSLDIR>
+      <CVS_RSH>ssh</CVS_RSH>
+      <SSH_CONNECTION>152.16.195.158 2993 10.152.25.5 22</SSH_CONNECTION>
+      <MODULESHOME>/usr/share/Modules</MODULESHOME>
+      <LESSOPEN>|/usr/bin/lesspipe.sh %s</LESSOPEN>
+      <SHLIB_PATH>/opt/globus-client-5.0.0.rc3-r1/lib</SHLIB_PATH>
+      <DISPLAY>localhost:10.0</DISPLAY>
+      <FSLLOCKDIR></FSLLOCKDIR>
+      <FSLOUTPUTTYPE>NIFTI_GZ</FSLOUTPUTTYPE>
+      <G_BROKEN_FILENAMES>1</G_BROKEN_FILENAMES>
+      <module>() {  eval `/usr/bin/modulecmd bash $*`
+}</module>
+      <OLDPWD>/home/gadde/checkedout/ProvenanceLibrary</OLDPWD>
     </entity>
+    <entity id="e_0"/>
+    <entity id="e_0"/>
     <dependencies>
-      <used id="u_0">
-        <activity ref="a_0"/>
-        <entity ref="e_0"/>
-      </used>
-      <used id="u_1">
-        <activity ref="a_0"/>
-        <entity ref="e_1"/>
-      </used>
-      <used id="u_2">
-        <activity ref="a_0"/>
-        <entity ref="e_2"/>
-      </used>
       <wasGeneratedBy id="wgb_0">
-        <entity ref="e_5"/>
-        <activity ref="a_0"/>
-      </wasGeneratedBy>
-      <wasGeneratedBy id="wgb_1">
-        <entity ref="e_6"/>
+        <entity ref="e_0"/>
         <activity ref="a_0"/>
       </wasGeneratedBy>
     </dependencies>
-    <entity id="e_1">
-      <type>input</type>
-      <arg2>2</arg2>
-    </entity>
-    <entity id="e_2">
-      <type>input</type>
-      <arg3>-m</arg3>
-    </entity>
-    <entity id="e_3">
-      <type>environment</type>
-      <PATH>/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:/usr/X11/bin:/opt/local/bin:/usr/local/git/bin</PATH>
-      <TMPDIR>/var/folders/1l/ly3rt98n1sd4cdw03l7ncf1r0000gn/T/</TMPDIR>
-      <LOGNAME>satra</LOGNAME>
-      <COMMAND_MODE>unix2003</COMMAND_MODE>
-      <DISPLAY>/tmp/launch-9Dx8oH/org.macosforge.xquartz:0</DISPLAY>
-      <Apple_PubSub_Socket_Render>/tmp/launch-PeLnXj/Render</Apple_PubSub_Socket_Render>
-      <USER>satra</USER>
-      <SHELL>/bin/bash</SHELL>
-      <SSH_AUTH_SOCK>/tmp/launch-hjVTaO/Listeners</SSH_AUTH_SOCK>
-      <HOME>/Users/satra</HOME>
-    </entity>
-    <entity id="e_4">
-      <type>runtime</type>
-    </entity>
-    <entity id="e_5">
-      <type>output:file</type>
-      <warped_file>/full/path/to/file</warped_file>
-    </entity>
-    <entity id="e_6">
-      <type>output:stat</type>
-      <pearson_correlation_coefficient>.234</pearson_correlation_coefficient>
-    </entity>
+    <entity id="e_0"/>
+    <dependencies>
+      <wasGeneratedBy id="wgb_0">
+        <entity ref="e_0"/>
+        <activity ref="a_0"/>
+      </wasGeneratedBy>
+    </dependencies>
   </records>
 </container>

--- a/src/testprov2.xml
+++ b/src/testprov2.xml
@@ -1,74 +1,90 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<container xmlns:opm="http://openprovenance.org/prov-xml#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:prov="http://openprovenance.org/prov-xml#" xmlns:incf="http://incf.org/incf-schema" id="1">
+<container xmlns:opm="http://openprovenance.org/prov-xml#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:prov="http://openprovenance.org/prov-xml#" xmlns:incf="http://incf.org/incf-schema" xmlns:ni="http://this.namespace.needs.to/be.decided" xmlns="http://openprovenance.org/prov-xml#" id="1">
   <records>
     <account id="ac_0">
-      <records>
+      <records xmlns="http://openprovenance.org/prov-xml#" xmlns:prov="http://openprovenance.org/prov-xml#" xmlns:ni="http://this.namespace.needs.to/be.decided">
     <activity id="ac_0_a_0">
       <startTime>11/30/11 00:13:20.650432 EST</startTime>
       <endTime>11/30/11 00:13:20.650550 EST</endTime>
-      <type>program</type>
-      <name>/Users/satra/Dropbox/WORK/PROJECTS/INCF/ProvenanceLibrary/src/testprov</name>
-      <version>1.0.0</version>
-      <cmdline>/Users/satra/Dropbox/WORK/PROJECTS/INCF/ProvenanceLibrary/src/testprov -c 2 -m</cmdline>
+      <prov:type>program</prov:type>
+      <ni:name>./testprov</ni:name>
+      <ni:version>1.0.0</ni:version>
+      <ni:cmdline>./testprov</ni:cmdline>
     </activity>
     <entity id="ac_0_e_0">
-      <type>input</type>
-      <arg1>-c</arg1>
+      <prov:type>environment</prov:type>
+      <HOSTNAME>varese.dhe.duke.edu</HOSTNAME>
+      <SELINUX_ROLE_REQUESTED/>
+      <TERM>xterm</TERM>
+      <SHELL>/bin/bash</SHELL>
+      <HISTSIZE>1000</HISTSIZE>
+      <GLOBUS_PATH>/opt/globus-client-5.0.0.rc3-r1</GLOBUS_PATH>
+      <GLOBUS_LOCATION>/opt/globus-client-5.0.0.rc3-r1</GLOBUS_LOCATION>
+      <SSH_CLIENT>152.16.195.158 2993 22</SSH_CLIENT>
+      <PERL5LIB>/opt/globus-client-5.0.0.rc3-r1/lib/perl</PERL5LIB>
+      <FSLMULTIFILEQUIT>TRUE</FSLMULTIFILEQUIT>
+      <SELINUX_USE_CURRENT_RANGE/>
+      <QTDIR>/usr/lib64/qt-3.3</QTDIR>
+      <QTINC>/usr/lib64/qt-3.3/include</QTINC>
+      <SSH_TTY>/dev/pts/25</SSH_TTY>
+      <USER>gadde</USER>
+      <LD_LIBRARY_PATH>.</LD_LIBRARY_PATH>
+      <LS_COLORS>no=00:fi=00:di=01;36:ln=01;36:pi=40;33:so=01;35:bd=40;33;01:cd=40;33;01:or=01;05;37;41:mi=01;05;37;41:ex=01;32:*.cmd=01;32:*.exe=01;32:*.com=01;32:*.btm=01;32:*.bat=01;32:*.sh=01;32:*.csh=01;32:*.tar=01;31:*.tgz=01;31:*.arj=01;31:*.taz=01;31:*.lzh=01;31:*.zip=01;31:*.z=01;31:*.Z=01;31:*.gz=01;31:*.bz2=01;31:*.bz=01;31:*.tz=01;31:*.rpm=01;31:*.cpio=01;31:*.jpg=01;35:*.gif=01;35:*.bmp=01;35:*.xbm=01;35:*.xpm=01;35:*.png=01;35:*.tif=01;35:</LS_COLORS>
+      <LIBPATH>/opt/globus-client-5.0.0.rc3-r1/lib:/usr/lib:/lib</LIBPATH>
+      <MAIL>/var/spool/mail/gadde</MAIL>
+      <PATH>/usr/lib64/qt-3.3/bin:/opt/globus-client-5.0.0.rc3-r1/bin:/opt/globus-client-5.0.0.rc3-r1/sbin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:/usr/local/packages/bxh_xcede_tools/bin:/usr/local/packages/dcmtk/bin:/usr/local/packages/fsl/bin:/home/gadde/bin</PATH>
+      <FSLMACHTYPE>linux_64-gcc4.4</FSLMACHTYPE>
+      <PWD>/home/gadde/checkedout/ProvenanceLibrary/src</PWD>
+      <XMODIFIERS>@im=none</XMODIFIERS>
+      <KDE_IS_PRELINKED>1</KDE_IS_PRELINKED>
+      <LANG>en_US.UTF-8</LANG>
+      <MODULEPATH>/usr/share/Modules/modulefiles:/etc/modulefiles</MODULEPATH>
+      <FSLTCLSH>/usr/local/packages/fsl/bin/fsltclsh</FSLTCLSH>
+      <LOADEDMODULES/>
+      <KDEDIRS>/usr</KDEDIRS>
+      <FSLMACHINELIST/>
+      <MYPROXY_SERVER>certs.nbirn.org</MYPROXY_SERVER>
+      <SELINUX_LEVEL_REQUESTED/>
+      <FSLREMOTECALL/>
+      <FSLCONFDIR>/usr/local/packages/fsl/config</FSLCONFDIR>
+      <FSLWISH>/usr/local/packages/fsl/bin/fslwish</FSLWISH>
+      <SSH_ASKPASS>/usr/libexec/openssh/gnome-ssh-askpass</SSH_ASKPASS>
+      <HISTCONTROL>ignoredups</HISTCONTROL>
+      <SHLVL>1</SHLVL>
+      <HOME>/home/gadde</HOME>
+      <LANGUAGE/>
+      <DYLD_LIBRARY_PATH>/opt/globus-client-5.0.0.rc3-r1/lib</DYLD_LIBRARY_PATH>
+      <LOGNAME>gadde</LOGNAME>
+      <QTLIB>/usr/lib64/qt-3.3/lib</QTLIB>
+      <FSLDIR>/usr/local/packages/fsl</FSLDIR>
+      <CVS_RSH>ssh</CVS_RSH>
+      <SSH_CONNECTION>152.16.195.158 2993 10.152.25.5 22</SSH_CONNECTION>
+      <MODULESHOME>/usr/share/Modules</MODULESHOME>
+      <LESSOPEN>|/usr/bin/lesspipe.sh %s</LESSOPEN>
+      <SHLIB_PATH>/opt/globus-client-5.0.0.rc3-r1/lib</SHLIB_PATH>
+      <DISPLAY>localhost:10.0</DISPLAY>
+      <FSLLOCKDIR/>
+      <FSLOUTPUTTYPE>NIFTI_GZ</FSLOUTPUTTYPE>
+      <G_BROKEN_FILENAMES>1</G_BROKEN_FILENAMES>
+      <module>() {  eval `/usr/bin/modulecmd bash $*`
+}</module>
+      <OLDPWD>/home/gadde/checkedout/ProvenanceLibrary</OLDPWD>
     </entity>
+    <entity id="ac_0_e_0"/>
+    <entity id="ac_0_e_0"/>
     <dependencies>
-      <used id="ac_0_u_0">
-        <activity ref="ac_0_a_0"/>
-        <entity ref="ac_0_e_0"/>
-      </used>
-      <used id="ac_0_u_1">
-        <activity ref="ac_0_a_0"/>
-        <entity ref="ac_0_e_1"/>
-      </used>
-      <used id="ac_0_u_2">
-        <activity ref="ac_0_a_0"/>
-        <entity ref="ac_0_e_2"/>
-      </used>
       <wasGeneratedBy id="ac_0_wgb_0">
-        <entity ref="ac_0_e_5"/>
-        <activity ref="ac_0_a_0"/>
-      </wasGeneratedBy>
-      <wasGeneratedBy id="ac_0_wgb_1">
-        <entity ref="ac_0_e_6"/>
+        <entity ref="ac_0_e_0"/>
         <activity ref="ac_0_a_0"/>
       </wasGeneratedBy>
     </dependencies>
-    <entity id="ac_0_e_1">
-      <type>input</type>
-      <arg2>2</arg2>
-    </entity>
-    <entity id="ac_0_e_2">
-      <type>input</type>
-      <arg3>-m</arg3>
-    </entity>
-    <entity id="ac_0_e_3">
-      <type>environment</type>
-      <PATH>/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:/usr/X11/bin:/opt/local/bin:/usr/local/git/bin</PATH>
-      <TMPDIR>/var/folders/1l/ly3rt98n1sd4cdw03l7ncf1r0000gn/T/</TMPDIR>
-      <LOGNAME>satra</LOGNAME>
-      <COMMAND_MODE>unix2003</COMMAND_MODE>
-      <DISPLAY>/tmp/launch-9Dx8oH/org.macosforge.xquartz:0</DISPLAY>
-      <Apple_PubSub_Socket_Render>/tmp/launch-PeLnXj/Render</Apple_PubSub_Socket_Render>
-      <USER>satra</USER>
-      <SHELL>/bin/bash</SHELL>
-      <SSH_AUTH_SOCK>/tmp/launch-hjVTaO/Listeners</SSH_AUTH_SOCK>
-      <HOME>/Users/satra</HOME>
-    </entity>
-    <entity id="ac_0_e_4">
-      <type>runtime</type>
-    </entity>
-    <entity id="ac_0_e_5">
-      <type>output:file</type>
-      <warped_file>/full/path/to/file</warped_file>
-    </entity>
-    <entity id="ac_0_e_6">
-      <type>output:stat</type>
-      <pearson_correlation_coefficient>.234</pearson_correlation_coefficient>
-    </entity>
+    <entity id="ac_0_e_0"/>
+    <dependencies>
+      <wasGeneratedBy id="ac_0_wgb_0">
+        <entity ref="ac_0_e_0"/>
+        <activity ref="ac_0_a_0"/>
+      </wasGeneratedBy>
+    </dependencies>
   </records>
     </account>
   </records>


### PR DESCRIPTION
Add a prefix parameter to addAttribute().  Change all calls to addAttribute to specify a prefix.  For any "type" attributes, they are now qualified with the "prov" prefix.  Any other explicitly named attributes are given the "ni" prefix.  That leaves attributes whose names are data-driven (like environment variables), and for now these get a NULL prefix.  addAttribute() allows prefix to be NULL, but W3C PROV may require that attributes have a namespace prefix so this may need to be revisited.
